### PR TITLE
Update pom.xml of backend/web

### DIFF
--- a/backend/web/pom.xml
+++ b/backend/web/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
+            <version>2.8.9</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
chore: upgrade springdoc-openapi to 2.8.9 for Spring Boot 3.4.2 compatibility

Updated dependency `springdoc-openapi-starter-webmvc-ui` from version 2.3.0 to 2.8.9 to ensure compatibility with Spring Boot 3.4.2 (based on Spring Framework 6.2.x).  Previous versions of springdoc used a removed constructor (`ControllerAdviceBean(Object)`), which caused runtime errors.

This update resolves the NoSuchMethodError and ensures stability when accessing the OpenAPI JSON and Swagger UI endpoints.