### PR TITLE
feat: persist language selection in a configurable cookie

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -265,7 +265,17 @@ export class AppComponent implements OnInit, AfterViewInit {
 		this.translate.setDefaultLang(this.language.getDefaultLanguagesCode());
 		this.authentication.currentAccountIsAuthenticated() && this.authentication.getUserProfileCulture() ? this.cultureService.cultureSelected(this.authentication.getUserProfileCulture()) : this.cultureService.cultureSelected(this.configurationService.defaultCulture);
 		this.authentication.currentAccountIsAuthenticated() && this.authentication.getUserProfileTimezone() ? this.timezoneService.timezoneSelected(this.authentication.getUserProfileTimezone()) : this.timezoneService.timezoneSelected(this.configurationService.defaultTimezone);
-		this.authentication.currentAccountIsAuthenticated() && this.authentication.getUserProfileLanguage() ? this.language.changeLanguage(this.authentication.getUserProfileLanguage()) : (this.language.getDefaultLanguagesCode());
+		if (this.authentication.currentAccountIsAuthenticated() && this.authentication.getUserProfileLanguage()) {
+			this.language.changeLanguage(this.authentication.getUserProfileLanguage());
+		} else {
+			const cookieLang = this.language.getCookieLanguage();
+			const availableLangs = this.language.getAvailableLanguagesCodes();
+			if (cookieLang && availableLangs.includes(cookieLang)) {
+				this.language.changeLanguage(cookieLang);
+			} else {
+				this.language.changeLanguage(this.language.getDefaultLanguagesCode());
+			}
+		}
 
 		this.authentication.getAuthenticationStateObservable().subscribe(authenticationState => {
 			if (authenticationState.loginStatus === LoginStatus.LoggedIn) {

--- a/frontend/src/app/core/services/configuration/configuration.service.ts
+++ b/frontend/src/app/core/services/configuration/configuration.service.ts
@@ -35,6 +35,16 @@ export class ConfigurationService extends BaseComponent {
 		return this._defaultCulture || 'en';
 	}
 
+	private _languageCookieName: string;
+	get languageCookieName(): string {
+		return this._languageCookieName || 'opencdmp_lang';
+	}
+
+	private _languageCookieDomain: string;
+	get languageCookieDomain(): string {
+		return this._languageCookieDomain || '';
+	}
+
 	private _defaultTimezone: string;
 	get defaultTimezone(): string {
 		return this._defaultTimezone || 'UTC';
@@ -266,6 +276,10 @@ export class ConfigurationService extends BaseComponent {
 		this._server = config.Server;
 		this._app = config.App;
 		this._defaultCulture = config.defaultCulture;
+		if (config.languageCookie) {
+			this._languageCookieName = config.languageCookie.name;
+			this._languageCookieDomain = config.languageCookie.domain;
+		}
 		this._defaultTimezone = config.defaultTimezone;
 		this._keycloak = KeycloakConfiguration.parseValue(config.keycloak);
 		this._logging = Logging.parseValue(config.logging);

--- a/frontend/src/app/core/services/language/language.service.ts
+++ b/frontend/src/app/core/services/language/language.service.ts
@@ -1,9 +1,11 @@
 import { Injectable, Signal, signal } from '@angular/core';
 import { BaseService } from '@common/base/base.service';
 import { TranslateService } from '@ngx-translate/core';
+import { CookieService } from 'ngx-cookie-service';
 import { Observable } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
 import { LanguageHttpService } from './language.http.service';
+import { ConfigurationService } from '../configuration/configuration.service';
 
 @Injectable()
 export class LanguageService extends BaseService {
@@ -18,7 +20,9 @@ export class LanguageService extends BaseService {
 
 	constructor(
 		private translate: TranslateService,
-		private languageHttpService: LanguageHttpService
+		private languageHttpService: LanguageHttpService,
+		private configurationService: ConfigurationService,
+		private cookieService: CookieService
 	) {
 		super();
 	}
@@ -26,6 +30,15 @@ export class LanguageService extends BaseService {
 	public changeLanguage(lang: string) {
 		this.currentLanguage = lang;
 		this.translate.use(lang);
+		this.setLanguageCookie(lang);
+	}
+
+	public getCookieLanguage(): string | null {
+		return this.cookieService.get(this.configurationService.languageCookieName) || null;
+	}
+
+	private setLanguageCookie(lang: string): void {
+		this.cookieService.set(this.configurationService.languageCookieName, lang, 5000, null, this.configurationService.languageCookieDomain || null, false, 'Lax');
 	}
 
 	public getCurrentLanguage() {

--- a/frontend/src/assets/config/config.json
+++ b/frontend/src/assets/config/config.json
@@ -2,6 +2,10 @@
 	"Server": "${WEBAPP_API_URL}",
 	"App": "${INSTALLATION_URL}",
 	"defaultCulture": "${DEFAULT_CULTURE}",
+	"languageCookie": {
+		"name": "${LANGUAGE_COOKIE_NAME}",
+		"domain": "${LANGUAGE_COOKIE_DOMAIN}"
+	},
 	"keycloak": {
 		"enabled": true,
 		"address": "${KEYCLOAK_ADDRESS}",

--- a/frontend/start_nginx.sh
+++ b/frontend/start_nginx.sh
@@ -23,6 +23,18 @@ else
    find '/usr/share/nginx/html/assets/config' -name 'config.json' -exec sed -i -e 's,${DEFAULT_CULTURE},en,g' {} \;
 fi
 
+if [[ ! -z "${LANGUAGE_COOKIE_NAME}" ]]; then
+	find '/usr/share/nginx/html/assets/config' -name 'config.json' -exec sed -i -e 's,${LANGUAGE_COOKIE_NAME},'"$LANGUAGE_COOKIE_NAME"',g' {} \;
+else
+   find '/usr/share/nginx/html/assets/config' -name 'config.json' -exec sed -i -e 's,${LANGUAGE_COOKIE_NAME},,g' {} \;
+fi
+
+if [[ ! -z "${LANGUAGE_COOKIE_DOMAIN}" ]]; then
+	find '/usr/share/nginx/html/assets/config' -name 'config.json' -exec sed -i -e 's,${LANGUAGE_COOKIE_DOMAIN},'"$LANGUAGE_COOKIE_DOMAIN"',g' {} \;
+else
+   find '/usr/share/nginx/html/assets/config' -name 'config.json' -exec sed -i -e 's,${LANGUAGE_COOKIE_DOMAIN},,g' {} \;
+fi
+
 if [[ ! -z "${KEYCLOAK_ADDRESS}" ]]; then
 	find '/usr/share/nginx/html/assets/config' -name 'config.json' -exec sed -i -e 's,${KEYCLOAK_ADDRESS},'"$KEYCLOAK_ADDRESS"',g' {} \;
 else


### PR DESCRIPTION
### Description
Store the user's language preference in a cookie so it survives page reloads for unauthenticated users. When an authenticated user has a language configured in their profile, it takes precedence and overwrites the cookie value. 

Cookie name and domain are configurable via `LANGUAGE_COOKIE_NAME` and `LANGUAGE_COOKIE_DOMAIN` environment variables.

### Related Issue
Closes #7

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing
- Selected a language as an unauthenticated user and triggered a full page reload to confirm the cookie persists.
- Logged in as an authenticated user to verify the profile language setting correctly overrides the cookie.
- Tested configuration via `LANGUAGE_COOKIE_NAME` and `LANGUAGE_COOKIE_DOMAIN` environment variables.